### PR TITLE
Added a meaningful error message while publishing the courses

### DIFF
--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -55,6 +55,14 @@ class CourseRunViewSet(viewsets.GenericViewSet):
             if content:
                 logger.error(content)
             raise
+        except ValueError as ex:
+            message = "It looks like your course data is not completed yet. Please complete it before publishing the " \
+                      "course. If the issue persists please contact your Administrator."
+            logger.exception('Failed to publish course run [%s]!', pk)
+            content = getattr(ex, 'content', None)
+            if content:
+                logger.error(content)
+            return Response(message, status=502)
 
         status_code = status.HTTP_200_OK
         for _status in publication_status.values():


### PR DESCRIPTION
### Story:
[Error on publishing a course](https://edlyio.atlassian.net/browse/EDE-497)

### Description:
While publishing the course from the Publisher, it shows "Server Error". This issue occurs because course data is not completed. 

### Testing:
- Go to the publisher.
- Create a course without adding a course image.
- Try to publish a course from Publisher.

#### Expected Behaviour:
- While Publishing the course if course data is not complete, it must show the meaningful error message instead of "Server Error".