### PR TITLE
Add management commands to create publisher roles for users and organizations

### DIFF
--- a/course_discovery/apps/publisher/management/commands/add_users_to_group.py
+++ b/course_discovery/apps/publisher/management/commands/add_users_to_group.py
@@ -1,0 +1,116 @@
+"""
+Add users to the specified groups
+"""
+import logging
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import BaseCommand, CommandError
+from django.db.models import Q
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Add users to the specified groups
+
+    Example usage:
+        ```
+        python manage.py add_users_to_group -g "Publisher Admins" "Internal Users"\
+            "ucsd-admins" "edx-admins"\
+            -u edx staff -s -f filename.txt
+        ```
+    """
+    help = 'Create required and missing groups and roles for the courses imported from studio.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-g',
+            '--groups',
+            action='store',
+            dest='groups',
+            nargs='+',
+            required=True,
+            help=('Name of the group.')
+        )
+
+        parser.add_argument(
+            '-u',
+            '--users',
+            action='store',
+            dest='users',
+            required=False,
+            nargs='*',
+            help=('Usernames or emails for the users.')
+        )
+
+        parser.add_argument(
+            '-s',
+            '--staff',
+            action='store_true',
+            dest='for_all_staff',
+            required=False,
+            help=('Add all staff users to the group.')
+        )
+
+        parser.add_argument(
+            '-f',
+            '--file',
+            action='store',
+            dest='filename',
+            required=False,
+            help=('Name of the file having usernames/emails of the users.')
+        )
+
+    def handle(self, *args, **options):
+        users = self.get_users(options)
+        groups = self.get_groups(options)
+        for group in groups:
+            for user in users:
+                user.groups.add(group)
+                logger.info('Added user {} in group {}'.format(user, group))
+
+    def get_users(self, options):
+        if (
+            not options.get('for_all_staff') and
+            not options.get('users') and
+            not options.get('filename')
+        ):
+            raise CommandError(
+                'At least one of the options,"-u username [username ...]",'
+                ' "-s", or "-f [FILENAME]" are required'
+            )
+
+        all_users = User.objects.all()
+        users = []
+
+        if options.get('for_all_staff'):
+            logger.info('Publisher roles will be created for all staff users.')
+            users += all_users.filter(is_staff=True)
+
+        if options.get('users'):
+            users += all_users.filter(
+                Q(username__in=options['users']) |
+                Q(email__in=options['users'])
+            )
+
+        if options.get('filename'):
+            usernames = self.read_usernames_from_file(options['filename'])
+            users += all_users.filter(
+                Q(username__in=usernames) |
+                Q(email__in=usernames)
+            )
+
+        return users
+
+    def read_usernames_from_file(self, filename):
+        with open(filename, 'r') as input_file:
+            return [user.strip() for user in input_file.read().split('\n') if user]
+
+    def get_groups(self, options):
+        groups = [group.strip() for group in options['groups'] if group]
+        if groups == ['__ALL__']:
+            return Group.objects.all()
+        return Group.objects.filter(name__in=groups)

--- a/course_discovery/apps/publisher/management/commands/create_publisher_roles.py
+++ b/course_discovery/apps/publisher/management/commands/create_publisher_roles.py
@@ -1,0 +1,255 @@
+"""
+Create/update required groups and roles for courses
+imported from metadata into publisher.
+"""
+import logging
+
+import six
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import BaseCommand
+
+from course_discovery.apps.course_metadata.models import Organization
+from course_discovery.apps.publisher.assign_permissions import assign_permissions
+from course_discovery.apps.publisher.choices import InternalUserRole, PublisherUserRole
+
+from course_discovery.apps.publisher.models import Course as PublisherCourse
+from course_discovery.apps.publisher.models import CourseUserRole, OrganizationExtension, OrganizationUserRole
+
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+PARTNER_MANAGER_USER_USERNAME = 'edx_partner_manager_user'
+PROJECT_COORDINATOR_USER_USERNAME = 'edx_project_cordinator_user'
+MARKETING_USER_USERNAME = 'edx_marketing_user'
+PUBLISHER_USER_USERNAME = 'edx_publisher_user'
+COURSE_TEAM_USER_USERNAME = 'edx_course_team_user'
+
+PARTNER_MANAGER = InternalUserRole.PartnerManager
+PROJECT_COORDINATOR = InternalUserRole.ProjectCoordinator
+MARKETING_REVIEWER = InternalUserRole.MarketingReviewer
+PUBLISHER = InternalUserRole.Publisher
+COURSE_TEAM = PublisherUserRole.CourseTeam
+
+INTERNAL_USER_ROLES = InternalUserRole.values.keys()
+PUBLISHER_USER_ROLES = PublisherUserRole.values.keys()
+
+
+def log_message_prefix(is_created):
+    if is_created:
+        return 'Created '
+    return 'Found existing'
+
+
+class Command(BaseCommand):
+    """
+    Run this command after importing courses metadata into publisher.
+
+    Running this command will create the following for the specified organizations:
+    - Organization Extension
+    - Groups
+    - Organization User roles
+    - Course user roles
+    - Update course(s)' number.
+
+    Example usage:
+        ```
+        python manage.py create_publisher_roles -o __ALL__ \
+            --partner_manager  edx_partner_manager_user\
+            --project_coordinator edx_project_cordinator_user\
+            --marketing_reviewer edx_marketing_user\
+            --publisher edx_publisher_user\
+            --course_team edx
+        ```
+    """
+    help = 'Create required and missing groups and roles for the courses imported from studio.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-o',
+            '--organizations',
+            action='store',
+            dest='organizations',
+            required=True,
+            nargs='+',
+            help=('Organization(s) for which to create the groups and roles. '
+                  'use "__ALL__" for all organizations')
+        )
+
+        parser.add_argument(
+            '--partner_manager',
+            action='store',
+            dest=PARTNER_MANAGER,
+            default=PARTNER_MANAGER_USER_USERNAME,
+            required=False,
+            help=('Username for the role "Partner Manager" for organization and course.')
+        )
+
+        parser.add_argument(
+            '--project_coordinator',
+            action='store',
+            dest=PROJECT_COORDINATOR,
+            default=PROJECT_COORDINATOR_USER_USERNAME,
+            required=False,
+            help=('Username for the role "Project Coordinator" for organization and course.')
+        )
+
+        parser.add_argument(
+            '--marketing_reviewer',
+            action='store',
+            dest=MARKETING_REVIEWER,
+            default=MARKETING_USER_USERNAME,
+            required=False,
+            help=('Username for the role "Marketing Reviewer" for organization and course.')
+        )
+
+        parser.add_argument(
+            '--publisher',
+            action='store',
+            dest=PUBLISHER,
+            default=PUBLISHER_USER_USERNAME,
+            required=False,
+            help=('Username for the role "Publisher" for organization and course.')
+        )
+
+        parser.add_argument(
+            '--course_team',
+            action='store',
+            dest=COURSE_TEAM,
+            default=COURSE_TEAM_USER_USERNAME,
+            required=False,
+            help=('Username for the role "Course Team" for course.')
+        )
+
+    def handle(self, *args, **options):
+        users = self.get_users(options)
+        organizations = self.get_organizations(options)
+
+        org_roles = self.create_organization_roles(users, organizations)
+        groups = self.create_organization_group(organizations)
+        self.link_groups_with_users(users, groups)
+
+        org_courses = self.get_authored_courses(organizations)
+
+        self.update_publisher_courses(org_courses, users)
+
+    def get_users(self, options):
+        return {
+            PARTNER_MANAGER: User.objects.get(username=options[PARTNER_MANAGER]),
+            PROJECT_COORDINATOR: User.objects.get(username=options[PROJECT_COORDINATOR]),
+            MARKETING_REVIEWER: User.objects.get(username=options[MARKETING_REVIEWER]),
+            PUBLISHER: User.objects.get(username=options[PUBLISHER]),
+            COURSE_TEAM: User.objects.get(username=options[COURSE_TEAM]),
+        }
+
+    def get_organizations(self, options):
+        organizations = options.get('organizations')
+        if organizations == ['__ALL__']:
+            logger.info('Publisher roles will be created for all existing organizations.')
+            return Organization.objects.all()
+        return Organization.objects.filter(key__in=organizations)
+
+    def create_organization_roles(self, users, organizations):
+        org_roles = {}
+        for org in organizations:
+            roles = []
+            for role in INTERNAL_USER_ROLES:
+                try:
+                    org.organization_user_roles.get(
+                        role=role,
+                    )
+                    logger.info('{} role {} for organization {}'.format(
+                        log_message_prefix(False), role, org
+                    ))
+                except OrganizationUserRole.DoesNotExist:
+                    org.organization_user_roles.create(
+                        role=role,
+                        user=users[role]
+                    )
+                    logger.info('{} role {} for organization {}'.format(
+                        log_message_prefix(True), role, org
+                    ))
+                roles.append(role)
+
+            org_roles[org.key] = roles
+
+        return org_roles
+
+    def create_organization_group(self, organizations):
+        groups = {}
+        for org in organizations:
+            group, created = Group.objects.get_or_create(name='{}-admins'.format(org.key))
+            logger.info('{} group {} for organization {}'.format(
+                log_message_prefix(created), group, org
+            ))
+
+            extension, created = OrganizationExtension.objects.get_or_create(
+                group=group,
+                organization=org
+            )
+
+            # Assign appropriate permission to the group so that any user
+            # can change the users for course roles
+            assign_permissions(extension)
+
+            logger.info('{} organization extension {} for organization {}'.format(
+                log_message_prefix(created), extension, org
+            ))
+
+            groups[org.key] = group
+        return groups
+
+    def link_groups_with_users(self, users, groups):
+        for user in six.itervalues(users):
+            for _, group in six.iteritems(groups):
+                user.groups.add(group)
+                logger.info('Added user {} to group {}'.format(
+                    user, group
+                ))
+
+    def get_authored_courses(self, organizations):
+        return {
+            org.key: org.authored_courses.all() for org in organizations
+        }
+
+    def update_publisher_courses(self, org_courses, users):
+        publisher_courses = PublisherCourse.objects.all()
+        for org, courses in six.iteritems(org_courses):
+            for course in courses:
+                pub_course = publisher_courses.get(course_metadata_pk=course.pk)
+                course_number = course.key.split('+')[1]
+                pub_course.number = course_number
+                pub_course.save()
+                logger.info('Updated course number {} for course {}'.format(
+                    course_number, course
+                ))
+                self.create_roles_for_course(pub_course, users)
+
+    def create_roles_for_course(self, course, users):
+        # TODO add every user to "Publisher Admins" groups to display courses and edit courses team users
+        # TODO: make a separate command for managing user roles
+        # Publisher admin users can view all courses but can edit only the courses
+        # authored by their organizations
+        # Internal users can change the users for different roles
+        for role in PUBLISHER_USER_ROLES:
+            try:
+                course_user_role = CourseUserRole.objects.get(
+                    course=course,
+                    role=role
+                )
+                logger.info('{} course user role {} for course {}'.format(
+                    log_message_prefix(False), course_user_role, course
+                ))
+
+            except CourseUserRole.DoesNotExist:
+                course_user_role = CourseUserRole.objects.create(
+                    course=course,
+                    user=users[role],
+                    role=role
+                )
+                logger.info('{} course user role {} for course {}'.format(
+                    log_message_prefix(True), course_user_role, course
+                ))

--- a/course_discovery/apps/publisher/serializers.py
+++ b/course_discovery/apps/publisher/serializers.py
@@ -9,7 +9,7 @@ from rest_framework import serializers
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.publisher.mixins import check_course_organization_permission
 from course_discovery.apps.publisher.models import OrganizationExtension
-from course_discovery.apps.publisher.utils import has_role_for_course
+from course_discovery.apps.publisher.utils import has_course_access
 
 
 class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -79,6 +79,6 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
         try:
             return check_course_organization_permission(
                 user, course, OrganizationExtension.EDIT_COURSE
-            ) and has_role_for_course(course, user)
+            ) and has_course_access(course, user)
         except ObjectDoesNotExist:
             return False

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -2562,7 +2562,9 @@ class CourseDetailViewTests(TestCase):
         self.course_team_role.save()
 
         # Verify that user cannot see edit button if he has no role for course.
-        self.assert_can_edit_permission(can_edit=False)
+        # [UCSD_CUSTOM] Updated the code to allow admin publisher to access course
+        # even if they don't have any role for the course.
+        self.assert_can_edit_permission(can_edit=True)
 
     def test_detail_page_with_role_widgets(self):
         """

--- a/course_discovery/apps/publisher/utils.py
+++ b/course_discovery/apps/publisher/utils.py
@@ -116,6 +116,14 @@ def has_role_for_course(course, user):
     return course.course_user_roles.filter(user=user).exists()
 
 
+def has_course_access(course, user):
+    return (
+        has_role_for_course(course, user) or
+        is_internal_user(user) or
+        is_publisher_admin(user)
+    )
+
+
 def parse_datetime_field(date):
     """
     Parse datetime field to make same format YYYY-MM-DD 00:00:00.

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -37,7 +37,7 @@ from course_discovery.apps.publisher.models import (
     PublisherUser, Seat, UserAttributes
 )
 from course_discovery.apps.publisher.utils import (
-    get_internal_users, has_role_for_course, is_internal_user, is_project_coordinator_user, is_publisher_admin,
+    get_internal_users, has_course_access, is_internal_user, is_project_coordinator_user, is_publisher_admin,
     make_bread_crumbs
 )
 from course_discovery.apps.publisher.wrappers import CourseRunWrapper
@@ -182,7 +182,7 @@ class CourseRunDetailView(mixins.LoginRequiredMixin, mixins.PublisherPermissionM
 
         context['can_edit'] = mixins.check_course_organization_permission(
             user, course_run.course, OrganizationExtension.EDIT_COURSE_RUN
-        ) and has_role_for_course(course_run.course, user)
+        ) and has_course_access(course_run.course, user)
 
         context['role_widgets'] = get_course_role_widgets_data(
             user, course_run.course, course_run.course_run_state, 'publisher:api:change_course_run_state'
@@ -667,7 +667,7 @@ class CourseDetailView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMixi
 
         context['can_edit'] = mixins.check_course_organization_permission(
             user, course, OrganizationExtension.EDIT_COURSE
-        ) and has_role_for_course(course, user)
+        ) and has_course_access(course, user)
 
         context['breadcrumbs'] = make_bread_crumbs(
             [


### PR DESCRIPTION
### Story link:
https://edlyio.atlassian.net/browse/EDE-782

### Description:
Add a new management command that will import courses from metadata into publisher (same as the original command `import_metadata_courses` but add new functionality.

Running this command can now create courses as well as:
- Organizations
- Organization Extension
- Groups
- Organization User roles
- Course user roles

**Example usage**:
```
python manage.py create_missing_roles -u edx -o edx --start_id 1 --end_id 10
```