### PR TITLE
Rename the organization names created using the command

### DIFF
--- a/course_discovery/apps/publisher/management/commands/add_users_to_group.py
+++ b/course_discovery/apps/publisher/management/commands/add_users_to_group.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
     Example usage:
         ```
         python manage.py add_users_to_group -g "Publisher Admins" "Internal Users"\
-            "ucsd-admins" "edx-admins"\
+            "ucsd Admins" "edx Admins"\
             -u edx staff -s -f filename.txt
         ```
     """

--- a/course_discovery/apps/publisher/management/commands/create_publisher_roles.py
+++ b/course_discovery/apps/publisher/management/commands/create_publisher_roles.py
@@ -181,7 +181,7 @@ class Command(BaseCommand):
     def create_organization_group(self, organizations):
         groups = {}
         for org in organizations:
-            group, created = Group.objects.get_or_create(name='{}-admins'.format(org.key))
+            group, created = Group.objects.get_or_create(name='{} Admins'.format(org.key))
             logger.info('{} group {} for organization {}'.format(
                 log_message_prefix(created), group, org
             ))


### PR DESCRIPTION
## Description
Rename the organization names created using the management command from `ORG-admins` to `ORG Admins` for more user friendly names